### PR TITLE
Fix missing scientificgo import

### DIFF
--- a/fft_test.go
+++ b/fft_test.go
@@ -11,8 +11,8 @@ import (
 
 	ktyefft "github.com/ktye/fft"
 	dspfft "github.com/mjibson/go-dsp/fft"
+	scientificfft "github.com/scientificgo/fft"
 	gonumfft "gonum.org/v1/gonum/dsp/fourier"
-	scientificfft "scientificgo.org/fft"
 )
 
 // Slow is the simplest and slowest FFT transform, for testing purposes

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.12
 require (
 	github.com/ktye/fft v0.0.0-20230429065932-51351a1ec012
 	github.com/mjibson/go-dsp v0.0.0-20180508042940-11479a337f12
+	github.com/scientificgo/fft v0.0.2
 	gonum.org/v1/gonum v0.13.0
-	scientificgo.org/fft v0.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
+github.com/scientificgo/fft v0.0.2 h1:K6Wv+FhMnEYVNJ2MCsNm/UAyRNt3QayNOwZWAILee84=
+github.com/scientificgo/fft v0.0.2/go.mod h1:SlHsUoEbd3eNM1tk8QUgaSt+HJCn1Cxi6mBUwNfcgHc=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
@@ -141,7 +143,3 @@ gonum.org/v1/plot v0.9.0/go.mod h1:3Pcqqmp6RHvJI72kgb8fThyUnav364FOsdDo2aGW5lY=
 gonum.org/v1/plot v0.10.1/go.mod h1:VZW5OlhkL1mysU9vaqNHnsy86inf6Ot+jB3r+BczCEo=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
-scientificgo.org/fft v0.0.0 h1:8nq6H5e0HY9ba+aie7+vz8an5xdBQZ7a2rnyZ3iQCHo=
-scientificgo.org/fft v0.0.0/go.mod h1:RAwyHm5LB0BYJ5LcHBZO6wo2brPH2kuIFLgC0P+O260=
-scientificgo.org/testutil v0.0.0 h1:y356DHRo0tAz9zIFmxlhZoKDlHPHaWW/DCm9k3PhIMA=
-scientificgo.org/testutil v0.0.0/go.mod h1:Go6R4b+9YkFocMo3H3vNQ7tjbrX9Rc12wal7NZjvPXg=


### PR DESCRIPTION
The scientificgo/fft package imported for the benchmarks moved from their domain to github: https://pkg.go.dev/scientificgo.org/fft. 

This PR just updates to the new URL so this library is importable.